### PR TITLE
Fixed windows 11 BDW_CUSTOM_FRAME error

### DIFF
--- a/windows/bitsdojo_window.cpp
+++ b/windows/bitsdojo_window.cpp
@@ -256,7 +256,11 @@ namespace bitsdojo_window {
     }
 
     LRESULT handle_nccalcsize(HWND window, WPARAM wparam, LPARAM lparam)
-    {
+    {        
+        if (!wparam)
+        {
+            return 0;
+        }
         auto params = reinterpret_cast<NCCALCSIZE_PARAMS*>(lparam);
         adjustMaximizedSize(window, params->lppos);
         adjustMaximizedRects(window,params);


### PR DESCRIPTION
This fixes application crashes on windows 11 and is based on the original PR here: https://github.com/bitsdojo/bitsdojo_window/pull/134